### PR TITLE
tools/scylla-nodetool: add restore integration

### DIFF
--- a/dist/common/nodetool-completion
+++ b/dist/common/nodetool-completion
@@ -149,6 +149,7 @@ have nodetool && have cqlsh &&
             relocatesstables
             removenode
             repair
+            restore
             scrub
             setcachecapacity
             setcachekeystosave

--- a/docs/operating-scylla/nodetool-commands/restore.rst
+++ b/docs/operating-scylla/nodetool-commands/restore.rst
@@ -1,0 +1,29 @@
+================
+Nodetool restore
+================
+
+**restore** - Load SSTables from a designated bucket in object store into a specified keyspace or table
+
+Syntax
+------
+
+.. code-block:: console
+
+   nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
+               --endpoint <endpoint> --bucket <bucket>
+               --snapshot <snapshot>
+               --keyspace <keyspace> [--table <table>]
+               [--nowait]
+
+Options
+-------
+
+* ``-h <host>`` or ``--host <host>`` - Node hostname or IP address.
+* ``--endpoint`` - ID of the configured object storage endpoint to load SSTables from
+* ``--bucket`` - Name of the bucket to load SSTables from
+* ``--snapshot`` - Name of a snapshot to load SSTables from
+* ``--keyspace`` - Name of a keyspace to load SSTables into
+* ``--table`` - Name of a table to load SSTables into
+* ``--nowait`` - Don't wait on the restore process
+
+.. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -42,6 +42,7 @@ Nodetool
    nodetool-commands/removenode
    nodetool-commands/repair
    nodetool-commands/resetlocalschema
+   nodetool-commands/restore
    nodetool-commands/ring
    nodetool-commands/scrub
    nodetool-commands/settraceprobability
@@ -122,6 +123,7 @@ Operations that are not listed below are currently not available.
 * :doc:`refresh </operating-scylla/nodetool-commands/refresh/>`- Load newly placed SSTables to the system without restart
 * :doc:`removenode </operating-scylla/nodetool-commands/removenode/>`- Remove node with the provided ID
 * :doc:`repair <nodetool-commands/repair/>`  :code:`<keyspace>` :code:`<table>` - Repair one or more tables
+* :doc:`restore </operating-scylla/nodetool-commands/restore/>` - Load SSTables from a designated bucket in object store into a specified keyspace or table
 * :doc:`resetlocalschema </operating-scylla/nodetool-commands/resetlocalschema/>` - Reset the node's local schema.
 * :doc:`ring <nodetool-commands/ring/>` - The nodetool ring command display the token ring information.
 * :doc:`scrub </operating-scylla/nodetool-commands/scrub>` :code:`[-m mode] [--no-snapshot] <keyspace> [<table>...]` - Scrub the SSTable files in the specified keyspace or table(s)

--- a/test/nodetool/test_restore.py
+++ b/test/nodetool/test_restore.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+
+from test.nodetool.rest_api_mock import expected_request
+
+@pytest.mark.parametrize("table",
+                         ["cf",
+                          pytest.param("",
+                                       marks=pytest.mark.xfail(
+                                           reason="full keyspace restore not implemented yet"))])
+@pytest.mark.parametrize("nowait", [False, True])
+def test_restore(nodetool, scylla_only, table, nowait):
+    endpoint = "s3.us-east-2.amazonaws.com"
+    bucket = "bucket-foo"
+    keyspace = "ks"
+
+    snapshot = "ss"
+    params = {"endpoint": endpoint,
+              "bucket": bucket,
+              "snapshot": snapshot,
+              "keyspace": keyspace}
+    if table:
+        params["table"] = table
+
+    task_id = "2c4a3e5f"
+    start_time = "2024-08-08T14:29:25Z"
+    end_time = "2024-08-08T14:30:42Z"
+    state = "done"
+    task_status = {
+        "id": task_id,
+        "type": "download_sstables",
+        "kind": "node",
+        "scope": "node",
+        "state": state,
+        "is_abortable": False,
+        "start_time": start_time,
+        "end_time": end_time,
+        "error": "",
+        "sequence_number": 0,
+        "shard": 0,
+        "progress_total": 1.0,
+        "progress_completed": 1.0,
+        "children_ids": []
+    }
+    expected_requests = [
+        expected_request(
+            "POST",
+            "/storage_service/restore",
+            params,
+            response=task_id)
+    ]
+    args = ["restore",
+            "--endpoint", endpoint,
+            "--bucket", bucket,
+            "--snapshot", snapshot,
+            "--keyspace", keyspace]
+    if table:
+        args.extend(["--table", table])
+    if nowait:
+        args.append("--nowait")
+        expected_output = ""
+    else:
+        # wait for the completion of backup task
+        expected_requests.append(
+            expected_request(
+                "GET",
+                f"/task_manager/wait_task/{task_id}",
+                response=task_status))
+        expected_output = f"""{state}
+start: {start_time}
+end: {end_time}
+"""
+    res = nodetool(*args, expected_requests=expected_requests)
+    assert res.stdout == expected_output


### PR DESCRIPTION
as we have an API for restore a keyspace / table, let's expose this feature with nodetool. so we can exercise it without the help of scylla-manager or 3rd-party tools with a user-friendly interface.

in this change:

* add a new subcommand named "restore" to nodetool
* add test to verify its interaction with the API server
* update the document accordingly.
* the bash completion script is updated accordingly.

**Please replace this line with justification for the backport/\* labels added to this PR**