### PR TITLE
encrypted_file_impl: Fixup of encrypted_data_source

### DIFF
--- a/ent/encryption/encrypted_file_impl.cc
+++ b/ent/encryption/encrypted_file_impl.cc
@@ -702,76 +702,91 @@ std::unique_ptr<data_sink_impl> make_encrypted_sink(data_sink sink, shared_ptr<s
 }
 
 class encrypted_data_source : public data_source_impl, public block_encryption_base {
-    data_source _source;
-    std::vector<char> _buffer;
-    size_t current_position = 0;
+    input_stream<char> _input;
+    temporary_buffer<char> _next;
+    size_t _current_position = 0;
+    size_t _skip = 0;
 
 public:
-    encrypted_data_source(data_source source, shared_ptr<symmetric_key> k) : block_encryption_base(std::move(k)), _source(std::move(source)) {
-        _buffer.reserve(block_size * 2);
-    }
+    encrypted_data_source(data_source source, shared_ptr<symmetric_key> k) 
+        : block_encryption_base(std::move(k))
+        , _input(std::move(source)) 
+    {}
 
     future<temporary_buffer<char>> get() override {
-        while (_buffer.size() < block_size) {
-            auto buf = co_await _source.get();
-            if (buf.empty()) {
-                break;
-            }
-            std::move(std::make_move_iterator(buf.get_write()), std::make_move_iterator(buf.get_write() + buf.size()), std::back_inserter(_buffer));
+        // First, get as much as we can get now (or the remainder of previous call)
+        auto buf1 = _next.empty()
+            ? co_await _input.read()
+            : std::exchange(_next, {})
+            ;
+
+        // eof?
+        if (buf1.empty()) {
+            co_return buf1;
+        }
+
+        // now we need one page more to be able to save one for next lap
+        auto fill_size = align_up(buf1.size(), block_size) + block_size - buf1.size();
+        auto buf2 = co_await _input.read_exactly(fill_size);
+
+        temporary_buffer<char> output(buf1.size() + buf2.size());
+
+        // we copy data even for the part we will cache. this to
+        // fix block alignment of the resulting shared buffer.
+        std::copy(buf1.begin(), buf1.end(), output.get_write());
+        std::copy(buf2.begin(), buf2.end(), output.get_write() + buf1.size());
+
+        // we need to keep one page buffered (beyond the input stream buffer - would be neat 
+        // to share it), to be able to detect actual eof stream size. We always need
+        // at least _two_ pages of data to process, to be able to handle the case where
+        // actual size is <aligned block size> - <less than key block size>.
+        // I.e. stream size = 8180, encrypted data size will be 8192, and data stream
+        // will be 8196. So we need to make sure buf1 == [4096-8192], and buf2 == [8192-8196].
+        if (is_aligned(output.size(), block_size) && output.size() >= 2*block_size) {
+            _next = output.share(output.size() - block_size, block_size);
+            output.trim(output.size() - block_size);
         }
 
         const size_t key_block_size = _key->block_size();
-        const size_t bytes_to_consume = _buffer.size() < block_size ? align_down(_buffer.size(), key_block_size) : align_down(_buffer.size(), block_size);
-        temporary_buffer<char> output(bytes_to_consume);
-        size_t decrypted_bytes = 0;
 
-        for (size_t offset = 0; offset < bytes_to_consume; offset += block_size) {
-            auto iv = iv_for(current_position + offset);
-            // Determine how many bytes remain in this block
-            const size_t remaining = std::min<uint64_t>(block_size, bytes_to_consume - offset);
-
-            // If the remaining bytes form a partial block, align down to a whole block size
-            size_t bytes_to_decrypt = (remaining < block_size) ? align_down(remaining, key_block_size) : block_size;
-
-            _key->transform_unpadded(mode::decrypt, _buffer.data() + offset, bytes_to_decrypt, output.get_write() + offset, iv.data());
-            decrypted_bytes += bytes_to_decrypt;
-
-            // If we've processed a partial (last) block, exit the loop
-            if (remaining < block_size) {
-                break;
-            }
+        // decrypt all blocks we have to return. might include the last, partial block
+        for (size_t offset = 0; offset < output.size(); offset += block_size, _current_position += block_size) {
+            auto iv = iv_for(_current_position);
+            auto rem = std::min(block_size, output.size() - offset);
+            _key->transform_unpadded(mode::decrypt, output.get() + offset, align_down(rem, key_block_size), output.get_write() + offset, iv.data());
         }
 
-        // Adjust the buffer size to the actual decrypted data length
-        output.trim(decrypted_bytes);
-        current_position += decrypted_bytes;
-        auto remaining_bytes = _buffer.size() - decrypted_bytes;
-        if (remaining_bytes > 0) {
-            // Move the remaining bytes to the front of the buffer
-            std::move(_buffer.begin() + decrypted_bytes, _buffer.end(), _buffer.begin());
-            _buffer.resize(remaining_bytes);
-        } else {
-            _buffer.clear();
+        // now, if the output buffer is not aligned, we are at eof, and
+        // also need to trim result.
+        if (!is_aligned(output.size(), key_block_size)) {
+            output.trim(output.size() - std::min(output.size(), key_block_size));
         }
+
+        assert(is_aligned(_current_position, block_size));
+        // finally trim front to handle any skip remainders
+        output.trim_front(std::min(std::exchange(_skip, 0), output.size()));
+
         co_return output;
     }
 
     future<temporary_buffer<char>> skip(uint64_t n) override {
-        auto aligned_position = align_down(current_position + n, block_size);
-        auto bytes_to_skip = aligned_position > current_position ? aligned_position - current_position : 0;
-        current_position = aligned_position;
-        // Remove "skipped" bytes from the buffer
-        if (!_buffer.empty()) {
-            if (bytes_to_skip >= _buffer.size()) {
-                _buffer.clear();
-            } else {
-                std::move(_buffer.begin() + bytes_to_skip, _buffer.end(), _buffer.begin());
-            }
+        if (n >= block_size) {
+            // since we only give back data aligned to block_size chunks,
+            // a client would only ever skip from a block boundary.
+            auto to_skip = align_down(n, block_size);
+            assert(is_aligned(_next.size(), block_size));
+            co_await _input.skip(to_skip - _next.size());
+            n -= to_skip;
+            _current_position += to_skip;
+            _next = {};
         }
-        return _source.skip(bytes_to_skip);
+        _skip = n;
+        co_return temporary_buffer<char>{};
     }
 
-    future<> close() override { return _source.close(); }
+    future<> close() override { 
+        return _input.close(); 
+    }
 };
 
 

--- a/test/boost/encrypted_file_test.cc
+++ b/test/boost/encrypted_file_test.cc
@@ -484,6 +484,8 @@ SEASTAR_TEST_CASE(test_encrypted_sink_data_large) {
 }
 
 static future<> test_random_data_source(std::vector<size_t> sizes) {
+    testlog.info("test_random_data_source with sizes: {} ({})", sizes, std::accumulate(sizes.begin(), sizes.end(), size_t(0), std::plus{}));
+
     auto name = "test_rand_source";
     std::vector<temporary_buffer<char>> bufs, srcs;
 
@@ -509,16 +511,55 @@ static future<> test_random_data_source(std::vector<size_t> sizes) {
     }
 
     {
-        auto os = co_await make_file_output_stream(co_await open_file_dma(dst, open_flags::wo | open_flags::create));
+        auto os = co_await make_file_output_stream(co_await open_file_dma(dst, open_flags::truncate|open_flags::wo | open_flags::create));
         for (auto& buf : bufs) {
             co_await os.write(buf.get(), buf.size());
         }
         co_await os.flush();
         co_await os.close();
     }
-    auto source = make_file_data_source(co_await open_file_dma(dst, open_flags::ro), file_input_stream_options{});
+
+    auto f = co_await open_file_dma(dst, open_flags::ro);
+    testlog.info("file source {}", (co_await f.stat()).st_size);
+
+    auto source = make_file_data_source(std::move(f), file_input_stream_options{});
+
+    class random_chunk_source 
+        : public data_source_impl
+    {
+        data_source _source;
+        temporary_buffer<char> _buf;
+    public:
+        random_chunk_source(data_source s)
+            : _source(std::move(s))
+        {}
+        future<temporary_buffer<char>> get() override {
+            if (!_buf.empty()) {
+                co_return std::exchange(_buf, temporary_buffer<char>{});
+            }
+            _buf = co_await _source.get();
+            if (_buf.empty()) {
+                co_return temporary_buffer<char>{};
+            }
+            auto n = tests::random::get_int(size_t(1), _buf.size());
+            auto res = _buf.share(0, n);
+            _buf.trim_front(n);
+            co_return res;
+        }
+        future<temporary_buffer<char>> skip(uint64_t n) override {
+            if (!_buf.empty()) {
+                auto m = std::min(n, _buf.size());
+                _buf.trim_front(m);
+                n -= m;
+            }
+            if (n) {
+                co_await _source.skip(n);
+            }
+            co_return temporary_buffer<char>{};
+        }
+    };
     try {
-        auto encrypted_source = data_source(make_encrypted_source(std::move(source), k));
+        auto encrypted_source = data_source(make_encrypted_source(data_source(std::make_unique<random_chunk_source>(std::move(source))), k));
         temporary_buffer<char> unified_buff(std::accumulate(srcs.begin(), srcs.end(), 0, [](size_t acc, const auto& buf) { return acc + buf.size(); }));
         size_t pos = 0;
         for (const auto& src : srcs) {
@@ -528,25 +569,32 @@ static future<> test_random_data_source(std::vector<size_t> sizes) {
 
         pos = 0;
         while (auto read_buff = co_await encrypted_source.get()) {
-            size_t size_to_compare = std::min(unified_buff.size() > pos ? unified_buff.size() - pos : std::numeric_limits<size_t>::max(), read_buff.size());
-            BOOST_REQUIRE_EQUAL(memcmp(read_buff.get(), unified_buff.get() + pos, size_to_compare), 0);
-            auto skip = unified_buff.size() - pos > 4113 ? 4097 : (unified_buff.size() - pos) / 2;
+            auto rem = unified_buff.size() - pos;
+            BOOST_REQUIRE_LE(read_buff.size(), rem);
+            size_t size_to_compare = std::min(rem, read_buff.size());
+            auto v1 = std::string_view(read_buff.get(), size_to_compare);
+            auto v2 = std::string_view(unified_buff.get() + pos, size_to_compare);
+            BOOST_REQUIRE_EQUAL(v1, v2);
+            auto skip = unified_buff.size() - pos > 4113 ? 4097 : (unified_buff.size() - pos)/2;
             co_await encrypted_source.skip(skip);
-            auto skipped = align_down(skip, 4096ul);
-            pos += size_to_compare + skipped;
-            if (pos >= unified_buff.size()) {
-                break;
-            }
+            pos += size_to_compare + skip;
         }
         co_await encrypted_source.close();
     } catch (...) {
         ex = std::current_exception();
     }
 
+
     if (ex) {
         std::rethrow_exception(ex);
     }
 }
+
+SEASTAR_TEST_CASE(test_encrypted_data_source_simple) {
+    std::vector<size_t> sizes({3200, 13086, 12065, 200, 11959, 12159, 12852});
+    co_await test_random_data_source(sizes);
+}
+
 
 SEASTAR_TEST_CASE(test_encrypted_data_source_fuzzy) {
     std::mt19937_64 rand_gen(std::random_device{}());
@@ -554,10 +602,9 @@ SEASTAR_TEST_CASE(test_encrypted_data_source_fuzzy) {
         std::uniform_int_distribution<uint16_t> rand_dist(1, 15);
         std::vector<size_t> sizes(rand_dist(rand_gen));
         for (auto& s : sizes) {
-            std::uniform_int_distribution<uint16_t> buff_sizes(1, 10000);
+            std::uniform_int_distribution<uint16_t> buff_sizes(1, 147*100);
             s = buff_sizes(rand_gen);
         }
-        testlog.info("test_random_data_source with sizes: {}", sizes);
         co_await test_random_data_source(sizes);
     }
 


### PR DESCRIPTION
Modifies the code to use stream for buffering, and handle both size alignment and skipping properly.
The buffering means we will do a fair bit of data shuffeling, but it is pretty much required to handle a generic underlying source.

